### PR TITLE
Clean Up Analytics

### DIFF
--- a/include/hypercomm/analytics.hpp
+++ b/include/hypercomm/analytics.hpp
@@ -70,7 +70,7 @@ envelope *pack_stats_(stats_registry_t &reg) {
   auto env = _allocEnv(CkEnvelopeType::ForBocMsg, size);
   PUP::toMem p((char *)EnvToUsr(env));
   p | reg;
-  CkAssertMsg(size == p.size(), "pup error!");
+  CkAssert(size == p.size() && "pup error!");
   return env;
 }
 

--- a/include/hypercomm/analytics.hpp
+++ b/include/hypercomm/analytics.hpp
@@ -1,6 +1,7 @@
 #ifndef __HYPERCOMM_ANALYTICS_HPP__
 #define __HYPERCOMM_ANALYTICS_HPP__
 
+#include <map>
 #include <mutex>
 #include <sstream>
 
@@ -14,89 +15,118 @@ struct stats_ {
   std::size_t nBytesAggregated;
   std::size_t nFlushes;
   double avgUtilizationAtFlush;
-};
-}
-}
 
-PUPbytes(aggregation::detail::stats_);
+  stats_(void)
+      : nAggregatedMessages(0), nBytesAggregated(0), nFlushes(0),
+        avgUtilizationAtFlush(0) {}
+
+  void pup(PUP::er &p) {
+    p | this->nAggregatedMessages;
+    p | this->nBytesAggregated;
+    p | this->nFlushes;
+    p | this->avgUtilizationAtFlush;
+  }
+
+  stats_ &operator+=(const stats_ &rhs) {
+    this->nAggregatedMessages += rhs.nAggregatedMessages;
+    this->nBytesAggregated += rhs.nBytesAggregated;
+    this->avgUtilizationAtFlush =
+        (this->avgUtilizationAtFlush * this->nFlushes +
+         rhs.avgUtilizationAtFlush * rhs.nFlushes) /
+        (this->nFlushes + rhs.nFlushes);
+    this->nFlushes += rhs.nFlushes;
+    return *this;
+  }
+
+  void tally_message(const msg_size_t size) {
+    this->nAggregatedMessages += 1;
+    this->nBytesAggregated += size;
+  }
+
+  void tally_flush(const float &utilization) {
+    auto &n = this->nFlushes;
+    auto &cma = this->avgUtilizationAtFlush;
+    cma = (utilization + n * cma) / (n + 1);
+    n += 1;
+  }
+};
+} // namespace detail
+} // namespace aggregation
 
 namespace aggregation {
 
 namespace {
-using stats_registry_t = std::vector<detail::stats_>;
-using node_lock_t = std::mutex;
-CkpvDeclare(int, send_stats_idx_);
-CksvDeclare(stats_registry_t, stats_registry_);
-#if CMK_SMP
-CksvDeclare(node_lock_t, node_lock_);
-#endif
+using stats_registry_t = std::map<endpoint_id_t, detail::stats_>;
 
-detail::stats_* stats_for(const endpoint_id_t& id) {
-  if (!CsvInitialized(stats_registry_)) {
-    CksvInitialize(stats_registry_t, stats_registry_);
-  }
-  auto reg = &(CksvAccess(stats_registry_));
-  if (reg->size() <= id) {
-    reg->resize(id + 1);
-  }
-  return &(*reg)[id];
+CkpvDeclare(int, send_stats_idx_);
+CkpvDeclare(stats_registry_t, stats_registry_);
+
+detail::stats_ &stats_for_(const endpoint_id_t &id) {
+  return (CkpvAccess(stats_registry_))[id];
 }
 
-envelope* pack_stats_(stats_registry_t& reg) {
-  auto numStats = reg.size();
-  PUP::sizer s;
-  s | numStats;
-  PUParray(s, reg.data(), numStats);
-  auto env = _allocEnv(CkEnvelopeType::ForBocMsg, s.size());
-  PUP::toMem p(EnvToUsr(env));
-  p | numStats;
-  PUParray(p, reg.data(), numStats);
-  CkAssert(p.size() == s.size() && "pup error");
+envelope *pack_stats_(stats_registry_t &reg) {
+  auto size = PUP::size(reg);
+  auto env = _allocEnv(CkEnvelopeType::ForBocMsg, size);
+  PUP::toMem p((char *)EnvToUsr(env));
+  p | reg;
+  CkAssertMsg(size == p.size(), "pup error!");
   return env;
 }
 
-// TODO evaluate whether CkAlign is necessary here
-void unpack_stats_(const envelope* env, std::size_t& numStats,
-                   detail::stats_*& stats) {
-  auto buffer = static_cast<char*>(EnvToUsr(env));
-  numStats = *(reinterpret_cast<std::size_t*>(buffer));
-  stats = reinterpret_cast<detail::stats_*>(buffer + sizeof(std::size_t));
+void unpack_stats_(envelope *env, stats_registry_t &reg) {
+  PUP::fromMem p((char *)EnvToUsr(env));
+  p | reg;
 }
 
-envelope* merge_stats_(envelope* left, envelope* right) {
+void combine_stats_(stats_registry_t &lhs, stats_registry_t &rhs) {
+  using value_type = typename stats_registry_t::value_type;
+  std::set<endpoint_id_t> keys;
+
+  auto helper = [](const value_type &val) { return val.first; };
+
+  std::transform(std::begin(lhs), std::end(lhs),
+                 std::inserter(keys, keys.begin()), helper);
+  std::transform(std::begin(rhs), std::end(rhs),
+                 std::inserter(keys, keys.begin()), helper);
+
+  for (auto &key : keys) {
+    auto search = rhs.find(key);
+    if (search != std::end(rhs)) {
+      lhs[key] += search->second;
+    }
+  }
+}
+
+envelope *merge_stats_(envelope *left, envelope *right) {
   if (left == nullptr || left->getUsersize() == 0) {
-    if (left) CmiFree(left);
+    if (left)
+      CmiFree(left);
     return right;
   } else if (right == nullptr || right->getUsersize() == 0) {
-    if (right) CmiFree(right);
+    if (right)
+      CmiFree(right);
     return left;
+  } else {
+    stats_registry_t ours, theirs;
+    unpack_stats_(left, ours);
+    unpack_stats_(right, theirs);
+
+    combine_stats_(ours, theirs);
+
+    CmiFree(left);
+    CmiFree(right);
+
+    return pack_stats_(ours);
   }
-
-  detail::stats_ *ours, *theirs;
-  std::size_t szOurs, szTheirs;
-
-  unpack_stats_(static_cast<envelope*>(left), szOurs, ours);
-  unpack_stats_(static_cast<envelope*>(right), szTheirs, theirs);
-  CkAssert(szOurs == szTheirs);
-
-  for (auto j = 0; j < szOurs; j += 1) {
-    ours[j].nAggregatedMessages += theirs[j].nAggregatedMessages;
-    ours[j].nBytesAggregated += theirs[j].nBytesAggregated;
-    ours[j].avgUtilizationAtFlush =
-        (ours[j].avgUtilizationAtFlush * ours[j].nFlushes +
-         theirs[j].avgUtilizationAtFlush * theirs[j].nFlushes) /
-        (ours[j].nFlushes + theirs[j].nFlushes);
-    ours[j].nFlushes += theirs[j].nFlushes;
-  }
-
-  CmiFree(right);
-  return left;
 }
 
-void print_stats_(const detail::stats_* reg, const std::size_t& szReg) {
+void print_stats_(stats_registry_t &registry) {
   std::stringstream ss;
-  for (std::size_t i = 0; i < szReg; i += 1) {
-    const auto& stats = reg[i];
+  for (auto &pair : registry) {
+    const auto &i = pair.first;
+    const auto &stats = pair.second;
+
     ss << std::endl << "[INFO] Data for Aggregator " << i << ":" << std::endl;
     ss << "\tnbr of flushes = " << stats.nFlushes << std::endl;
     ss << "\tnbr of messages aggregated = " << stats.nAggregatedMessages
@@ -113,28 +143,33 @@ void print_stats_(const detail::stats_* reg, const std::size_t& szReg) {
        << (100.0 * stats.avgUtilizationAtFlush) << "%" << std::endl;
   }
 
-  if (szReg == 0) {
+  if (registry.empty()) {
     ss << "[INFO] No aggregation data available." << std::endl;
   }
 
   CkPrintf("%s\n", ss.str().c_str());
 }
 
-void recv_stats_(void* impl_msg_) {
-  detail::stats_* reg;
-  std::size_t szReg;
-  auto env = static_cast<envelope*>(impl_msg_);
-  // otherwise, print the merged value
-  unpack_stats_(env, szReg, reg);
-  print_stats_(reg, szReg);
-  // and exit
+void recv_stats_(envelope *env) {
+  // print the merged value(s)
+  stats_registry_t merged;
+  unpack_stats_(env, merged);
+  print_stats_(merged);
   CmiFree(env);
+  // then exit
   CkContinueExit();
 }
 
-void send_stats_(void* _) {
-  hypercomm::reductions::node::contribute(
-      pack_stats_(CksvAccess(stats_registry_)), &recv_stats_, &merge_stats_);
+void send_stats_(void *_) {
+  auto &head = CkpvAccessOther(stats_registry_, 0);
+  for (auto rank = 1; rank < CmiNodeSize(CmiMyNode()); rank += 1) {
+    auto &next = CkpvAccessOther(stats_registry_, rank);
+    combine_stats_(head, next);
+  }
+
+  hypercomm::reductions::node::contribute(pack_stats_(head), &recv_stats_,
+                                          &merge_stats_);
+
   CmiFree(_);
 }
 
@@ -142,17 +177,14 @@ void exit_handler_(void) {
   auto env = _allocEnv(CkEnvelopeType::ForBocMsg, 0);
   CmiSetHandler(env, CkpvAccess(send_stats_idx_));
   CmiSyncNodeBroadcastAllAndFree(env->getTotalsize(),
-                                 reinterpret_cast<char*>(env));
+                                 reinterpret_cast<char *>(env));
 }
-}
+} // namespace
 
 namespace analytics {
 
 inline void initialize(void) {
-#if CMK_SMP
-  CksvInitialize(node_lock_t, node_lock_);
-#endif
-
+  CkpvInitialize(stats_registry_t, stats_registry_);
   CkpvInitialize(int, send_stats_idx_);
   CkpvAccess(send_stats_idx_) =
       CmiRegisterHandler(reinterpret_cast<CmiHandler>(&send_stats_));
@@ -164,32 +196,14 @@ inline void initialize(void) {
   }
 }
 
-void tally_message(const endpoint_id_t& id, const msg_size_t& size) {
-#if CMK_SMP
-  CksvAccess(node_lock_).lock();
-#endif
-  auto& stats = *(stats_for(id));
-  stats.nAggregatedMessages += 1;
-  stats.nBytesAggregated += size;
-#if CMK_SMP
-  CksvAccess(node_lock_).unlock();
-#endif
+void tally_message(const endpoint_id_t &id, const msg_size_t &size) {
+  stats_for_(id).tally_message(size);
 }
 
-void tally_flush(const endpoint_id_t& id, const float& utilization) {
-#if CMK_SMP
-  CksvAccess(node_lock_).lock();
-#endif
-  auto& stats = *(stats_for(id));
-  auto& n = stats.nFlushes;
-  auto& cma = stats.avgUtilizationAtFlush;
-  cma = (utilization + n * cma) / (n + 1);
-  n++;
-#if CMK_SMP
-  CksvAccess(node_lock_).unlock();
-#endif
+void tally_flush(const endpoint_id_t &id, const float &utilization) {
+  stats_for_(id).tally_flush(utilization);
 }
-}
-}
+} // namespace analytics
+} // namespace aggregation
 
 #endif


### PR DESCRIPTION
Rewrites the analytics logic to be more robust in the following ways:

- All PE's maintain their own statistics that are combined at the exit. (No node lock.)
- All statistics are zero-initialized, and manipulations are performed through methods.
- Statistics are un/packed using a more typical process, and no longer used "in-place".